### PR TITLE
Fix packaging metadata issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
-"""
-setup.py
-"""
-
+"""Setup script for QC Lab."""
+from pathlib import Path
 from setuptools import setup, find_packages
 
 VERSION = "0.1.0a3"
 DESCRIPTION = "QC Lab: a python package for quantum-classical modeling."
-LONG_DESCRIPTION = "QC Lab is a python package for quantum-classical modeling. It was developed in 2025 by the Tempelaar Team at Northwestern University."
+README = Path(__file__).with_name("README.rst")
+LONG_DESCRIPTION = README.read_text(encoding="utf-8")
+
 setup(
     name="qc_lab",
     version=VERSION,
@@ -14,12 +14,26 @@ setup(
     author_email="roel.tempelaar@northwestern.edu",
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
-    packages=find_packages(),
-    python_requires=">3.9,<3.14",
-    install_requires=["numpy<=1.26,>=1.22", "tqdm","h5py","numba<=0.60,>=0.58","matplotlib"],
-    extras_require={"test":["pytest", "mpi4py"]},
-    keywords=["surface hopping", "mixed quantum-classical dynamics",
-              "theoretical chemistry", "ehrenfest", "python", "quantum-classical"],
+    long_description_content_type="text/x-rst",
+    packages=find_packages(exclude=["tests", "tests.*"]),
+    python_requires=">=3.9,<3.14",
+    install_requires=[
+        "numpy>=1.22,<=1.26",
+        "tqdm",
+        "h5py",
+        "numba>=0.58,<=0.60",
+        "matplotlib",
+    ],
+    extras_require={"test": ["pytest", "mpi4py"]},
+    keywords=[
+        "surface hopping",
+        "mixed quantum-classical dynamics",
+        "theoretical chemistry",
+        "ehrenfest",
+        "python",
+        "quantum-classical",
+    ],
+    license="Apache-2.0",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Education",
@@ -27,6 +41,6 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: Linux :: Linux",
-        "License :: Apache License 2.0",
-    ]
+        "License :: OSI Approved :: Apache Software License",
+    ],
 )


### PR DESCRIPTION
## Summary
- load `long_description` from README
- exclude tests when finding packages
- correct python and dependency version specifiers
- add missing license metadata
- use proper Apache license classifier

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pytest mpi4py h5py tqdm numba matplotlib` *(fails: Failed building wheel for mpi4py)*

------
https://chatgpt.com/codex/tasks/task_e_6846e0839e5483239ddc6bb255ae40fd