### PR TITLE
Fix installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ This alpha release of QC Lab can be installed from source by downloading the rep
 
    pip install -e ./
 
-from inside its topmost directory (where the `setup.py` file is located).
+from inside its topmost directory (where the `pyproject.toml` file is located).
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ This alpha release of QC Lab can be installed from source by downloading the rep
 
    pip install -e ./
 
-from inside its topmost directory (where the `setup.py` file is located).
+from inside its topmost directory (where the `pyproject.toml` file is located).
 
 
 Nested Documentation

--- a/docs/nested_docs/install.rst
+++ b/docs/nested_docs/install.rst
@@ -68,7 +68,7 @@ Navigate into the QC Lab source directory and install via pip:
 
 This command will:
 
-- Read the `setup.py` in the source directory.
+- Read the `pyproject.toml` in the source directory.
 - Install QC Lab and any required dependencies into your active Python environment.
 
 If you wish to install in “editable” (development) mode so that changes in the source tree are immediately available, run:


### PR DESCRIPTION
## Summary
- mention `pyproject.toml` when installing in editable mode
- update install docs accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mpi4py')*

------
https://chatgpt.com/codex/tasks/task_e_684748b9170c8323b34abc502e7543a3