### PR TITLE
Add batch progress bars to dynamics drivers

### DIFF
--- a/src/qclab/dynamics/dynamics.py
+++ b/src/qclab/dynamics/dynamics.py
@@ -6,7 +6,7 @@ import numpy as np
 from tqdm import tqdm
 
 
-def run_dynamics(sim, state, parameters, data):
+def run_dynamics(sim, state, parameters, data, progress_reporter=None):
     """
     Dynamics core for QC Lab.
 
@@ -26,26 +26,35 @@ def run_dynamics(sim, state, parameters, data):
     """
     # Define an update iterator using tqdm if progress_bar is True.
     t_update_iterator = sim.settings.t_update_n
-    if getattr(sim.settings, "progress_bar", True):
+    use_internal_bar = progress_reporter is None and getattr(
+        sim.settings, "progress_bar", True
+    )
+    if use_internal_bar:
         t_update_iterator = tqdm(t_update_iterator)
 
     # Iterate over each time step.
-    for sim.t_ind in t_update_iterator:
-        if sim.t_ind == 0:
-            # Execute initialization recipe.
+    try:
+        for sim.t_ind in t_update_iterator:
+            if sim.t_ind == 0:
+                # Execute initialization recipe.
+                state, parameters = sim.algorithm.execute_recipe(
+                    sim, state, parameters, sim.algorithm.initialization_recipe
+                )
+            # Detect collect timesteps.
+            if np.mod(sim.t_ind, sim.settings.dt_collect_n) == 0:
+                # Calculate output variables.
+                state, parameters = sim.algorithm.execute_recipe(
+                    sim, state, parameters, sim.algorithm.collect_recipe
+                )
+                # Collect totals in output dictionary.
+                data.add_output_to_data_dict(sim, state, sim.t_ind)
+            # Execute update recipe.
             state, parameters = sim.algorithm.execute_recipe(
-                sim, state, parameters, sim.algorithm.initialization_recipe
+                sim, state, parameters, sim.algorithm.update_recipe
             )
-        # Detect collect timesteps.
-        if np.mod(sim.t_ind, sim.settings.dt_collect_n) == 0:
-            # Calculate output variables.
-            state, parameters = sim.algorithm.execute_recipe(
-                sim, state, parameters, sim.algorithm.collect_recipe
-            )
-            # Collect totals in output dictionary.
-            data.add_output_to_data_dict(sim, state, sim.t_ind)
-        # Execute update recipe.
-        state, parameters = sim.algorithm.execute_recipe(
-            sim, state, parameters, sim.algorithm.update_recipe
-        )
+            if progress_reporter is not None:
+                progress_reporter.update()
+    finally:
+        if progress_reporter is not None:
+            progress_reporter.close()
     return data

--- a/src/qclab/dynamics/parallel_driver_multiprocessing.py
+++ b/src/qclab/dynamics/parallel_driver_multiprocessing.py
@@ -5,10 +5,17 @@ This module contains the parallel driver using the multiprocessing library.
 import multiprocessing
 import logging
 import copy
+import time
+import threading
+import ctypes
 import numpy as np
 import qclab.dynamics as dynamics
 from qclab.utils import get_log_output, reset_log_output
 from qclab import Data
+from qclab.dynamics.progress import (
+    BatchProgressBars,
+    SharedValueProgressReporter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +84,12 @@ def parallel_driver_multiprocessing(sim, seeds=None, data=None, num_tasks=None):
     batch_seeds_list = batch_seeds_list.reshape((num_batches, sim.settings.batch_size))
     # Create the input data for each local simulation.
     sim.initialize_timesteps()
+    steps_per_batch = len(sim.settings.t_update_n)
+    progress_enabled = getattr(sim.settings, "progress_bar", True)
+    batch_bars = BatchProgressBars(
+        num_batches, steps_per_batch, enabled=progress_enabled
+    )
+    progress_values = []
     local_input_data = [
         (
             copy.deepcopy(sim),
@@ -86,6 +99,10 @@ def parallel_driver_multiprocessing(sim, seeds=None, data=None, num_tasks=None):
         )
         for n in range(num_batches)
     ]
+    if progress_enabled:
+        progress_values = [
+            multiprocessing.Value(ctypes.c_int, 0) for _ in range(num_batches)
+        ]
     for i in range(num_batches):
         # Determine the batch size from the seeds in the state object.
         local_input_data[i][0].settings.batch_size = len(local_input_data[i][1]["seed"])
@@ -93,13 +110,53 @@ def parallel_driver_multiprocessing(sim, seeds=None, data=None, num_tasks=None):
             "Running batch %s with seeds %s.", i + 1, local_input_data[i][1]["seed"]
         )
     logger.info("Starting dynamics calculation.")
+    monitor_thread = None
+    stop_event = threading.Event()
+    if progress_enabled and progress_values:
+        def _monitor_progress():
+            completed = 0
+            while not stop_event.is_set() and completed < num_batches:
+                snapshot = [val.value for val in progress_values]
+                completed = sum(1 for val in snapshot if val >= steps_per_batch)
+                running = [val for val in snapshot if val < steps_per_batch]
+                slowest = min(running) if running else steps_per_batch
+                batch_bars.set_total(completed)
+                batch_bars.set_slowest(slowest)
+                time.sleep(0.1)
+            batch_bars.set_total(num_batches)
+            batch_bars.set_slowest(steps_per_batch)
+
+        monitor_thread = threading.Thread(target=_monitor_progress, daemon=True)
+        monitor_thread.start()
+    worker_inputs = [
+        local_input_data[i]
+        + (
+            SharedValueProgressReporter(progress_values[i], steps_per_batch)
+            if progress_enabled
+            else None,
+        )
+        for i in range(num_batches)
+    ]
     with multiprocessing.Pool(processes=size) as pool:
-        results = pool.starmap(dynamics.run_dynamics, local_input_data)
+        results = pool.starmap(_run_batch_with_progress, worker_inputs)
+    stop_event.set()
+    if monitor_thread is not None:
+        monitor_thread.join()
     logger.info("Dynamics calculation completed.")
     logger.info("Collecting results from all tasks.")
     for result in results:
         data.add_data(result)
+    if progress_enabled:
+        batch_bars.close()
     logger.info("Simulation complete.")
     # Attach collected log output.
     data.log = get_log_output()
     return data
+
+
+def _run_batch_with_progress(sim, state, parameters, data, progress_reporter=None):
+    """Execute a single batch with an optional progress reporter."""
+
+    return dynamics.run_dynamics(
+        sim, state, parameters, data, progress_reporter=progress_reporter
+    )

--- a/src/qclab/dynamics/progress.py
+++ b/src/qclab/dynamics/progress.py
@@ -1,0 +1,111 @@
+"""Utility helpers for displaying dual progress bars for dynamics drivers."""
+
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from tqdm import tqdm
+
+
+class BatchProgressBars:
+    """Render two stacked progress bars for tracking batches.
+
+    The top bar tracks the number of completed batches. The bottom bar tracks the
+    progress of the slowest running batch measured in integration steps.
+    """
+
+    def __init__(
+        self,
+        total_batches: int,
+        steps_per_batch: int,
+        enabled: bool = True,
+        *,
+        position: int = 0,
+    ) -> None:
+        self.enabled = enabled and total_batches > 0 and steps_per_batch > 0
+        self.steps_per_batch = steps_per_batch
+        self._lock = threading.Lock()
+        if self.enabled:
+            self.total_bar = tqdm(
+                total=total_batches,
+                desc="Batches",
+                position=position,
+                leave=False,
+            )
+            self.slowest_bar = tqdm(
+                total=steps_per_batch,
+                desc="Slowest batch",
+                position=position + 1,
+                leave=False,
+            )
+        else:
+            self.total_bar = None
+            self.slowest_bar = None
+
+    def set_total(self, completed_batches: int) -> None:
+        """Update the overall batch bar to the provided completion count."""
+
+        if not self.enabled or self.total_bar is None:
+            return
+        with self._lock:
+            completed_batches = min(completed_batches, self.total_bar.total)
+            delta = completed_batches - self.total_bar.n
+            if delta > 0:
+                self.total_bar.update(delta)
+
+    def set_slowest(self, slowest_progress: int) -> None:
+        """Update the slowest batch bar to ``slowest_progress`` steps."""
+
+        if not self.enabled or self.slowest_bar is None:
+            return
+        with self._lock:
+            progress = max(0, min(slowest_progress, self.steps_per_batch))
+            self.slowest_bar.n = progress
+            self.slowest_bar.refresh()
+
+    def close(self) -> None:
+        """Close both progress bars."""
+
+        if not self.enabled:
+            return
+        if self.total_bar is not None:
+            self.total_bar.close()
+        if self.slowest_bar is not None:
+            self.slowest_bar.close()
+
+
+class SerialProgressReporter:
+    """Reporter used by drivers that execute batches sequentially."""
+
+    def __init__(self, bars: Optional[BatchProgressBars], steps_per_batch: int) -> None:
+        self.bars = bars
+        self.steps_per_batch = steps_per_batch
+        self.progress = 0
+        if self.bars is not None:
+            self.bars.set_slowest(0)
+
+    def update(self, steps: int = 1) -> None:
+        self.progress += steps
+        if self.bars is not None:
+            self.bars.set_slowest(self.progress)
+
+    def close(self) -> None:
+        if self.bars is not None:
+            self.bars.set_slowest(self.steps_per_batch)
+
+
+class SharedValueProgressReporter:
+    """Reporter that writes progress to a multiprocessing shared value."""
+
+    def __init__(self, shared_value, steps_per_batch: int) -> None:
+        self.shared_value = shared_value
+        self.steps_per_batch = steps_per_batch
+
+    def update(self, steps: int = 1) -> None:
+        with self.shared_value.get_lock():
+            self.shared_value.value += steps
+
+    def close(self) -> None:
+        with self.shared_value.get_lock():
+            self.shared_value.value = self.steps_per_batch


### PR DESCRIPTION
## Summary
- add a shared progress helper that renders paired progress bars for batch tracking
- update the serial, multiprocessing, and MPI drivers to report batch progress through the new helper
- let the dynamics core accept external progress reporters so each driver can drive its own output

## Testing
- `pytest tests/test_drivers.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bedbba4448323a1d9400be0ce3cd2)